### PR TITLE
Add API tests with jest and supertest

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,9 @@ const client = new Client({
       '--disable-gpu'
     ] }
 });
-client.initialize();
+if (process.env.NODE_ENV !== 'test') {
+  client.initialize();
+}
 
 io.on('connection', function(socket) {
   socket.emit('message', 'Server running...');
@@ -154,7 +156,10 @@ app.get('/group-participants', (req, res) => {
     });      
 });
 
+if (require.main === module) {
+  server.listen(port, function() {
+    console.log('App running on *: ' + port);
+  });
+}
 
-server.listen(port, function() {
-  console.log('App running on *: ' + port);
-});
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node app.js",
     "start:dev": "nodemon app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "whatsapp-api",
@@ -30,6 +30,8 @@
     "whatsapp-web.js": "^1.22.1"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest');
+
+jest.mock('whatsapp-web.js', () => {
+  const sendMessage = jest.fn().mockResolvedValue({});
+  const getChats = jest.fn().mockResolvedValue([]);
+  const getChatById = jest.fn().mockResolvedValue({ groupMetadata: { participants: [] }});
+  const Client = jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    sendMessage,
+    getChats,
+    getChatById,
+    on: jest.fn()
+  }));
+  return { Client, LocalAuth: jest.fn() };
+});
+
+process.env.NODE_ENV = 'test';
+const app = require('../app');
+
+describe('API endpoints', () => {
+  it('returns validation error for missing fields on /send-message', async () => {
+    const res = await request(app).post('/send-message').send({});
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('sends message successfully', async () => {
+    const res = await request(app)
+      .post('/send-message')
+      .send({ number: '5581999999999', message: 'hello' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe(true);
+  });
+
+  it('returns validation error when groupId is missing', async () => {
+    const res = await request(app).get('/group-participants');
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns chats successfully', async () => {
+    const res = await request(app).get('/chats');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest and supertest for API testing
- expose app without starting server when testing
- create sample API tests
- update `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d850570f08320966c6281e99e050e