### PR TITLE
Remove unused express-fileupload dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^1.4.0",
         "express": "^4.18.2",
-        "express-fileupload": "^1.4.0",
         "express-validator": "^7.0.1",
         "http": "^0.0.1-security",
         "mime-types": "^2.1.35",
@@ -401,17 +400,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.2.0"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -882,17 +870,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-fileupload": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
-      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/express-validator": {
@@ -2244,14 +2221,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "axios": "^1.4.0",
     "express": "^4.18.2",
-    "express-fileupload": "^1.4.0",
     "express-validator": "^7.0.1",
     "http": "^0.0.1-security",
     "mime-types": "^2.1.35",


### PR DESCRIPTION
## Summary
- remove express-fileupload from dependencies
- update lockfile after running `npm install --package-lock-only`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f12177083208125f2c1d90318f1