### PR TITLE
Add token auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Install dependencies: `npm install`
 
 Open a web browser `http://localhost:8080` and scan the QRCode.
 
+## Authentication
+
+Generate a token with:
+
+```
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Start the server with the token exported as `API_TOKEN`:
+
+```
+API_TOKEN=<token> npm start
+```
+
+Include this token in requests using the `Authorization` header or `api_key` query parameter.
 
 ## Endpoints
 
@@ -37,5 +52,4 @@ Get all chats (groups included).
 ### /group-participants
 
 Get all participants in a chat group.
-
 - Method: GET

--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ const qrcode = require('qrcode');
 const http = require('http');
 const axios = require('axios');
 const mime = require('mime-types');
+
+const API_TOKEN = process.env.API_TOKEN;
 const port = process.env.PORT || 8080;
 const app = express();
 const server = http.createServer(app);
@@ -17,6 +19,18 @@ app.use(express.urlencoded({
   extended: true
 }));
 app.use("/", express.static(__dirname + "/"))
+
+const validateToken = (req, res, next) => {
+  if (!API_TOKEN) return next();
+  const auth = req.headers['authorization'];
+  const token = auth && auth.startsWith('Bearer ') ? auth.substring(7) : req.query.api_key;
+  if (token !== API_TOKEN) {
+    return res.status(401).json({ status: false, message: 'Invalid API token' });
+  }
+  next();
+};
+
+app.use(validateToken);
 
 
 const client = new Client({


### PR DESCRIPTION
## Summary
- secure all routes with optional API token validation
- document how to create and use the token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d5137e8d48320a207b03f8c2b5c7c