### PR TITLE
Add webhook forwarding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ API_TOKEN=<token> npm start
 
 Include this token in requests using the `Authorization` header or `api_key` query parameter.
 
+Optionally define `WEBHOOK_URL` to automatically forward incoming messages to this URL:
+
+```
+WEBHOOK_URL=https://example.com/webhook npm start
+```
+
+You can update this value later using the `/webhook` endpoint.
+
 ## Endpoints
 
 ### /send-message
@@ -51,4 +59,32 @@ Get all chats (groups included).
 
 ### /group-participants
 
-Get all participants in a chat group.- Method: GET
+Get all participants in a chat group.
+
+- Method: GET
+
+### /webhook
+
+Configure the URL that will receive incoming WhatsApp messages.
+
+- Method: POST
+- Body:
+
+```
+{
+  "url": "https://example.com/webhook"
+}
+```
+
+#### Payload sent to the webhook
+
+When set, every incoming message triggers a POST request to the configured URL with the following JSON body:
+
+```
+{
+  "id": "<message id>",
+  "from": "<sender>",
+  "to": "<receiver>",
+  "body": "<message text>"
+}
+```


### PR DESCRIPTION
## Summary
- add `WEBHOOK_URL` environment variable
- implement `/webhook` endpoint for updating the webhook URL
- forward incoming messages via webhook when configured
- document new variable, endpoint, and payload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ebf8c7e0083209ca71091d3510453