### PR TITLE
Fix socket.io script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       <p id="logs"></p>
     </div>
 
-    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" integrity="sha384-PLACEHOLDER" crossorigin="anonymous"></script>
+    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
     <script>  
       document.addEventListener("DOMContentLoaded", function(e) {
         var socket = io();


### PR DESCRIPTION
## Summary
- fix the Socket.IO script tag by removing the incorrect integrity attribute

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ec845cdd08320b0692dd44d35275f