### PR TITLE
Remove vulnerable http dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "axios": "^1.4.0",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
-        "http": "^0.0.1-security",
         "mime-types": "^2.1.35",
         "qrcode": "^1.5.3",
         "socket.io": "^4.7.1",
@@ -1225,11 +1224,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/http": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
-      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "axios": "^1.4.0",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
-    "http": "^0.0.1-security",
     "mime-types": "^2.1.35",
     "qrcode": "^1.5.3",
     "socket.io": "^4.7.1",


### PR DESCRIPTION
## Summary
- remove deprecated `http` package from dependencies
- regenerate lockfile (manual update due to offline environment)

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686ec84d739083209b276edc4f84e8c0