### PR TITLE
Allow socket.io script in Helmet CSP

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,17 @@ const limiter = rateLimit({
   max: 100,
 });
 
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.socket.io"],
+        imgSrc: ["'self'", "data:"],
+      },
+    },
+  })
+);
 app.use(cors());
 app.use(limiter);
 app.use(express.json());


### PR DESCRIPTION
## Summary
- configure Helmet with custom Content Security Policy to allow loading the Socket.IO script from the CDN and executing inline scripts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f3f58987c8320a5e0e9736e17b362