### PR TITLE
Update webhook validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Get all participants in a chat group.
 
 Configure the URL that will receive incoming WhatsApp messages.
 
+The provided URL must be a valid HTTP or HTTPS address.
+
 - Method: POST
 - Body:
 

--- a/app.js
+++ b/app.js
@@ -57,8 +57,7 @@ app.post('/webhook', [
     .trim()
     .notEmpty()
     .isURL()
-    .withMessage('Invalid URL')
-    .escape(),
+    .withMessage('Invalid URL'),
 ], (req, res) => {
   const errors = validationResult(req).formatWith(({ msg }) => msg);
 
@@ -66,6 +65,15 @@ app.post('/webhook', [
     return res.status(422).json({
       status: false,
       message: errors.mapped(),
+    });
+  }
+
+  try {
+    new URL(req.body.url);
+  } catch (err) {
+    return res.status(422).json({
+      status: false,
+      message: { url: 'Invalid URL' },
     });
   }
 


### PR DESCRIPTION
## Summary
- validate /webhook URL using Node's URL
- note requirement for a valid URL in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889c12934988320a41cec2aa12c624d