### PR TITLE
Add health check endpoint and readiness tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ whatsapp-session*.json
 whatsapp-sessions.json
 .wwebjs_auth/
 .wwebjs_cache/
-ecosystem.config.js

--- a/README.md
+++ b/README.md
@@ -74,7 +74,20 @@ WEBHOOK_URL=https://example.com/webhook npm start
 
 You can update this value later using the `/webhook` endpoint.
 
+## Health check
+
+The server exposes `GET /healthz` which reports readiness. Use this route for
+health checks in Nginx or PM2. Example configuration files `nginx.conf` and
+`ecosystem.config.js` are provided.
+
 ## Endpoints
+
+### /healthz
+
+Health check endpoint. Returns status `200` only when the WhatsApp client is ready;
+otherwise responds with `503`.
+
+- Method: GET
 
 ### /send-message
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: 'whatsapp-n8n-server',
+      script: './app.js',
+      watch: false,
+      env: {
+        PORT: 8080,
+      },
+      // Use /healthz for PM2 healthchecks
+      health_check: {
+        url: 'http://localhost:8080/healthz',
+        interval: 5000,
+        timeout: 5000,
+      },
+    },
+  ],
+};

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Health check endpoint
+    location /healthz {
+        proxy_pass http://localhost:8080/healthz;
+    }
+}


### PR DESCRIPTION
## Summary
- track WhatsApp client readiness and expose `/healthz` endpoint
- add Nginx and PM2 configs using `/healthz` for health checks
- document health check endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a220ba44608320b28ad198f923c951