### PR TITLE
feat: configurable session and data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ WEBHOOK_URL=https://example.com/webhook npm start
 
 You can update this value later using the `/webhook` endpoint.
 
+Define optional variables `SESSION_NAME` and `DATA_PATH` to run multiple independent sessions:
+
+```
+SESSION_NAME=my-session DATA_PATH=/path/to/data npm start
+```
+
+The server aborts on start if another process is using the same `DATA_PATH`.
+
 ## Endpoints
 
 ### /send-message

--- a/app.js
+++ b/app.js
@@ -9,13 +9,58 @@ const mime = require('mime-types');
 const helmet = require('helmet');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
+const fs = require('fs');
+const path = require('path');
+
 const API_TOKEN = process.env.API_TOKEN;
+const SESSION_NAME = process.env.SESSION_NAME || 'client-one';
+const DATA_PATH = process.env.DATA_PATH || '.wwebjs_auth';
 let webhookUrl = process.env.WEBHOOK_URL || null;
 const port = process.env.PORT || 8080;
 const app = express();
 const server = http.createServer(app);
 const io = socketIO(server);
 const Util = require('./util/Util');
+
+const pidFile = path.join(DATA_PATH, `${SESSION_NAME}.pid`);
+
+function ensureSingleInstance() {
+  try {
+    fs.mkdirSync(DATA_PATH, { recursive: true });
+    if (fs.existsSync(pidFile)) {
+      const existingPid = parseInt(fs.readFileSync(pidFile, 'utf8'));
+      if (!isNaN(existingPid)) {
+        try {
+          process.kill(existingPid, 0);
+          console.error(
+            `Session already in use for data path ${DATA_PATH} by PID ${existingPid}`
+          );
+          process.exit(1);
+        } catch (err) {
+          fs.unlinkSync(pidFile);
+        }
+      }
+    }
+    fs.writeFileSync(pidFile, String(process.pid));
+    const cleanup = () => {
+      if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+    };
+    process.on('exit', cleanup);
+    process.on('SIGINT', () => {
+      cleanup();
+      process.exit(0);
+    });
+    process.on('SIGTERM', () => {
+      cleanup();
+      process.exit(0);
+    });
+  } catch (err) {
+    console.error('Failed to ensure single instance:', err.message);
+    process.exit(1);
+  }
+}
+
+ensureSingleInstance();
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -88,8 +133,9 @@ app.post('/webhook', [
 
 
 const client = new Client({
-  authStrategy: new LocalAuth({ clientId: 'client-one' }),
-  puppeteer: { headless: true,
+  authStrategy: new LocalAuth({ clientId: SESSION_NAME, dataPath: DATA_PATH }),
+  puppeteer: {
+    headless: true,
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
@@ -99,7 +145,8 @@ const client = new Client({
       '--no-zygote',
       '--single-process',
       '--disable-gpu'
-    ] }
+    ]
+  }
 });
 client.initialize();
 


### PR DESCRIPTION
## Summary
- allow custom session name and data directory via env vars
- prevent concurrent sessions by checking pidfile before boot
- document session and data path configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a220bacb5883208cb60c7a8fedd0bf