### PR TITLE
Require API token for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Open a web browser `http://localhost:8080` and scan the QRCode.
 
 ## Authentication
 
-Generate a token with:
+All requests require an API token. Generate a token with:
 
 ```
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
@@ -64,7 +64,7 @@ Start the server with the token exported as `API_TOKEN`:
 API_TOKEN=<token> npm start
 ```
 
-Include this token in requests using the `Authorization` header or `api_key` query parameter.
+Requests without this token, or with an invalid token, receive an `HTTP 401` response. Include the token using the `Authorization` header or `api_key` query parameter.
 
 Optionally define `WEBHOOK_URL` to automatically forward incoming messages to this URL:
 

--- a/app.js
+++ b/app.js
@@ -91,12 +91,30 @@ app.use(express.urlencoded({
 }));
 app.use("/", express.static(__dirname + "/"))
 const validateToken = (req, res, next) => {
-  if (!API_TOKEN) return next();
-  const auth = req.headers["authorization"];
-  const token = auth && auth.startsWith("Bearer ") ? auth.substring(7) : req.query.api_key;
-  if (token !== API_TOKEN) {
-    return res.status(401).json({ status: false, message: "Invalid API token" });
+  if (!API_TOKEN) {
+    return res
+      .status(401)
+      .json({ status: false, message: "API token is required" });
   }
+
+  const auth = req.headers["authorization"];
+  const token =
+    auth && auth.startsWith("Bearer ")
+      ? auth.substring(7)
+      : req.query.api_key;
+
+  if (!token) {
+    return res
+      .status(401)
+      .json({ status: false, message: "API token is required" });
+  }
+
+  if (token !== API_TOKEN) {
+    return res
+      .status(401)
+      .json({ status: false, message: "Invalid API token" });
+  }
+
   next();
 };
 


### PR DESCRIPTION
## Summary
- Enforce API token middleware to reject requests when `API_TOKEN` is unset, missing from requests, or invalid
- Document that an API token is mandatory for all endpoints

## Testing
- `npm test` (fails: Error: no test specified)
- `node` script simulating requests without an API token
- `API_TOKEN=secret node` script simulating requests without a provided token

------
https://chatgpt.com/codex/tasks/task_e_68a2684505688320b716a04e227de536