### PR TITLE
Add logger and log exit reasons on shutdown

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  info: (...args) => console.log(...args),
+  error: (...args) => console.error(...args),
+};


### PR DESCRIPTION
## Summary
- import logger and profile prep utilities
- log exit reasons via process.exit override and graceful shutdown
- ensure single instance using PID file

## Testing
- `npm test` (fails: Error: no test specified)
- `node app.js` (fails: Cannot find module 'whatsapp-web.js')

------
https://chatgpt.com/codex/tasks/task_e_68a26d7c28348320b251885adda002ed