### PR TITLE
fix: set trust proxy for rate limiter

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ let webhookUrl = process.env.WEBHOOK_URL || null;
 let ready = false;
 const port = process.env.PORT || 8080;
 const app = express();
+app.set('trust proxy', 1);
 app.set('isReady', true);
 const server = http.createServer(app);
 const io = socketIO(server);


### PR DESCRIPTION
## Summary
- trust first proxy so rate limiter can read real client IPs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fd2e91548320a6013cdc971abae9