### PR TITLE
Log full error details during init retries

### DIFF
--- a/app.js
+++ b/app.js
@@ -268,7 +268,24 @@ async function initWithRetries({ tries, baseDelayMs }) {
         /ProtocolError|TimeoutError|timed out/i.test(err?.message) || err?.name === 'TimeoutError';
 
       const transient = isNet || isTimeout || err?.name === 'TargetCloseError';
-      console.warn(`[init] attempt=${i} transient=${!!transient} err=`, err?.message);
+      const errInfo = {
+        message: err?.message,
+        stack: err?.stack,
+        name: err?.name,
+        code: err?.code,
+      };
+      console.warn(
+        `[init] attempt=${i} transient=${!!transient} err=${err?.message}`,
+        { name: errInfo.name, code: errInfo.code, stack: errInfo.stack }
+      );
+      logger.error(
+        JSON.stringify({
+          event: 'init.retry_error',
+          attempt: i,
+          transient: !!transient,
+          ...errInfo,
+        })
+      );
 
       if (!transient || i === tries) throw err;
 


### PR DESCRIPTION
## Summary
- log err.stack, err.name and err.code when init retries fail
- emit structured JSON log for downstream analysis

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb574138e883208456edc4ca8d1d77