### PR TITLE
chore: use official whatsapp-web.js release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "qrcode": "^1.5.3",
     "qrcode-terminal": "^0.12.0",
     "socket.io": "^4.7.1",
-    "whatsapp-web.js": "git+https://github.com/wesleysj/whatsapp-web.js.git#main"
+    "whatsapp-web.js": "^1.30.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"


### PR DESCRIPTION
## Summary
- use npm-hosted whatsapp-web.js

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm start` (fails: missing libatk-1.0.so.0)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bb66df35f88320841b733f16158baa