### PR TITLE
Log warnings for Chrome profile cleanup failures

### DIFF
--- a/util/prepareProfileDir.js
+++ b/util/prepareProfileDir.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const logger = require('./logger');
 
 /**
  * Ensure the profile directory exists and clean leftover Chrome locks.
@@ -31,13 +32,14 @@ function prepareProfileDir(
       .filter(Boolean);
   } catch (err) {
     pids = [];
+    logger.warn('Failed to find running Chrome processes:', err.message || err);
   }
 
   for (const pid of pids) {
     try {
       process.kill(Number(pid), 'SIGKILL');
     } catch (err) {
-      // ignore
+      logger.warn(`Failed to kill Chrome process ${pid}:`, err.message || err);
     }
   }
 


### PR DESCRIPTION
## Summary
- warn when `pgrep` fails to find Chrome processes
- log warning if killing a leftover Chrome process fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb679275108320b2db9033398643cb