### PR TITLE
Add warn method to logger to avoid runtime error

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   info: (...args) => console.log(...args),
+  warn: (...args) => console.warn(...args),
   error: (...args) => console.error(...args),
 };


### PR DESCRIPTION
## Summary
- Add missing `warn` method to logger utility used by prepareProfileDir

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7646cf748320b2cb030dd524e6af