### PR TITLE
fix: resolve data path relative to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Define optional variables `SESSION_NAME` and `DATA_PATH` to run multiple indepen
 SESSION_NAME=my-session DATA_PATH=/path/to/data npm start
 ```
 
+If `DATA_PATH` is omitted, a `.wwebjs_auth` folder is created inside the project
+directory by default.
+
 The server aborts on start if another process is using the same `DATA_PATH`.
 
 ## Health check

--- a/app.js
+++ b/app.js
@@ -17,7 +17,10 @@ const Util = require('./util/Util');
 const { prepareProfileDir } = require('./util/prepareProfileDir');
 
 const SESSION_NAME = process.env.SESSION_NAME || 'client-one';
-const DATA_PATH = process.env.DATA_PATH || '.wwebjs_auth';
+// Resolve data directory to avoid writing under an unexpected working directory
+const DATA_PATH = process.env.DATA_PATH
+  ? path.resolve(process.env.DATA_PATH)
+  : path.resolve(__dirname, '.wwebjs_auth');
 const chromePath =
   process.env.CHROME_PATH || process.env.PUPPETEER_EXECUTABLE_PATH;
 let webhookUrl = process.env.WEBHOOK_URL || null;


### PR DESCRIPTION
## Summary
- resolve default DATA_PATH relative to project directory to prevent permission errors
- document default session directory in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7ae8e0cc8320aaf3fca4de34c165